### PR TITLE
Remove a limit that is not there anymore.

### DIFF
--- a/doc_source/federated-limitations.md
+++ b/doc_source/federated-limitations.md
@@ -6,8 +6,7 @@ The following are limitations and considerations when using federated queries wi
 + Federated queries support read access to external data sources\. You can't write or create database objects in the external data source\.
 + In some cases, you might access an Amazon RDS or Aurora database in a different AWS Region than Amazon Redshift\. In these cases, you typically incur network latency and billing charges for transferring data across AWS Regions\. We recommend using an Aurora global database with a local endpoint in the same AWS Region as your Amazon Redshift cluster\. Aurora global databases use dedicated infrastructure for storage\-based replication across any two AWS Regions with typical latency of less than 1 second\. 
 + Consider the cost of accessing Amazon RDS or Aurora\. For example, when using this feature to access Aurora, Aurora charges are based on IOPS\.
-+ Federated queries don't enable access to Amazon Redshift from RDS or Aurora\. 
-+ Federated queries currently don't support access through materialized views\. 
++ Federated queries don't enable access to Amazon Redshift from RDS or Aurora\.
 + Federated queries are only available in AWS Regions where both Amazon Redshift and Amazon RDS or Aurora are available\. 
 + Federated queries currently don't support `ALTER SCHEMA`\. To change a schema, use `DROP` and then `CREATE EXTERNAL SCHEMA`\. 
 + Federated queries don't work with concurrency scaling\. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: as per https://aws.amazon.com/about-aws/whats-new/2020/06/amazon-redshift-materialized-views-support-external-tables the limit:
 "Federated queries currently don't support access through materialized views."
is not valid anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
